### PR TITLE
add more algorithms for CHAOS

### DIFF
--- a/src/chaos.c
+++ b/src/chaos.c
@@ -1,22 +1,122 @@
 #include "chaos.h"
 
-static chaos_state_t chaos_state = { 0.5, 3.75 };
+// constants defining I/O ranges
+static const int16_t chaos_value_min = -10000;
+static const int16_t chaos_value_max = 10000;
+static const int16_t chaos_param_min = 0;
+static const int16_t chaos_param_max = 10000;
+// fixed beta for henon map
+static const float chaos_henon_b = 0.3;
+// cellular automata parameters (1-d, binary)
+static const int chaos_cell_count = 8;
+static const int chaos_cell_max = 0xff;
 
-void chaos_set_val(int16_t val) {
-    chaos_state.value = (float)val / (10000.0);
+static chaos_state_t chaos_state = {
+  .ix = 5000,
+  .ir = 5000,
+  //  .algo = LOGISTIC
+  // .algo = CUBIC
+  // .algo = HENON
+};
+
+// scale integer state and param values to float, as appropriate for given algorithm
+static void chaos_scale_values(chaos_state_t* state) {
+  switch(state->algo) {
+  case HENON:
+    // for henon, x in [-1.5, 1.5], r in [1, 1.4]
+    state->fx = state->ix / (float)chaos_value_max * 1.5;
+    state->fr = 1.f + state->ir / (float)chaos_param_max * 0.4;
+    break;
+  case CELLULAR:
+    // 1d binary CA takes binary state and rule
+    if(state->ix > chaos_cell_max) { state->ix = chaos_cell_max; }
+    if(state->ix < 0 ) { state->ix = 0; }
+    // rule is 8 bits
+    if(state->ir > 0xff) { state->ir = 0xff; }
+    if(state->ir < 0 ) { state->ir = 0; }
+    break;
+  case LOGISTIC: // fall through
+  case CUBIC: // fall through
+  default:
+    // for cubic / logistic, x in [-1, 1] and r in [3.2, 4)
+    state->fx = state->ix / (float)chaos_value_max;
+    state->fr = state->ir / (float)chaos_param_max * 0.7999 + 3.2;
+    break;
+
+  }
 }
 
+void chaos_set_val(int16_t val) {  
+  chaos_state.ix = val;
+  chaos_scale_values(&chaos_state);
+}
+
+static int16_t logistic_get_val() {
+  chaos_state.fx =
+    chaos_state.fx * chaos_state.fr * (1.f - chaos_state.fx);
+  chaos_state.ix = chaos_state.fx * (float)chaos_value_max;
+  return chaos_state.ix;  
+}
+
+static int16_t cubic_get_val() {
+  float x3 = chaos_state.fx * chaos_state.fx * chaos_state.fx;    
+  chaos_state.fx = chaos_state.fr * x3 + chaos_state.fx * (1.f - chaos_state.fr);
+  chaos_state.ix = chaos_state.fx * (float)chaos_value_min;
+  return chaos_state.ix;
+}
+
+static int16_t henon_get_val() {
+  float x0_2 = chaos_state.fx0 * chaos_state.fx0;
+  float x = 1.f - (x0_2 * chaos_state.fr) + (chaos_henon_b * chaos_state.fx1);
+  // clamp to avoid blowup
+  if(x < -1.5) { x = -1.5; }
+  if(x > 1.5) { x = 1.5; }
+  chaos_state.fx1 = chaos_state.fx0;
+  chaos_state.fx0 = chaos_state.fx;
+  chaos_state.fx = x;
+  chaos_state.ix = x / 1.5 * (float)chaos_value_max;
+  return chaos_state.ix;
+}
+
+static int16_t cellular_get_val() {
+  uint8_t code = 0;
+  (void)code;
+  // TODO
+  /*
+    here's some old supercollider code.
+    NB: this is wrapping behavior.
+    the other alternative is to have endpoints fixed.
+
+    var code = 0; // 8 bit input to rule
+    code = code | (val[(i-1).wrap(0, n-1)] << 2);
+    code = code | (v << 1);
+    code = code | (val[(i+1).wrap(0, n-1)]);
+    val[i] = (rule & (1 << code)) >> code;
+   */
+  return 0;
+}
+
+
 int16_t chaos_get_val() {
-    // Logistic map
-    chaos_state.value =
-        chaos_state.r * chaos_state.value * (1.0 - chaos_state.value);
-    return (int16_t)(chaos_state.value * 10000);
+  switch(chaos_state.algo) {
+  case LOGISTIC:
+    return logistic_get_val();
+  case CUBIC:
+    return cubic_get_val();
+  case HENON:
+    return henon_get_val();
+  case CELLULAR:
+    return cellular_get_val();
+  default:
+    return 0;
+  }
 }
 
 void chaos_set_r(int16_t r) {
-    chaos_state.r = (float)r / 100.0;
-}
+  chaos_state.ir = r;
+  chaos_scale_values(&chaos_state);
+} 
 
 int16_t chaos_get_r() {
-    return (int16_t)(chaos_state.r * 100);
+  return chaos_state.ir;
 }

--- a/src/chaos.h
+++ b/src/chaos.h
@@ -2,9 +2,25 @@
 #define CHOAS_H
 #include <stdint.h>
 
+
+typedef enum {
+  LOGISTIC, // logistic map
+  CUBIC,    // cubic map
+  HENON,    // henon map
+  CELLULAR  // 1-d binary cellular automaton
+} chaos_algo_t;
+
+
+// keep value and parameter in both integer and float formats
+// this way, can switch algos on the fly and re-initialize (dunno if this is possible anyway)
 typedef struct {
-    float value;
-    float r;
+  int16_t ix;      // state value in integer format 
+  float fx;        // normalized floating point state value (as needed)
+  int16_t ir;        // parameter value in integer format
+  float fr;          // floating-point parm value (as needed)
+  float fx0;          // state history (as needed)
+  float fx1;          // state history (as needed)
+  chaos_algo_t algo; // current algorithm
 } chaos_state_t;
 
 void chaos_set_val(int16_t);


### PR DESCRIPTION
### you can merge this if you want, but haven't really done serious testing of the numerical output.

(that said, the algos themselves are simple and i've used them many times - output looks 'pretty close' so i wouldn't suspect anything is too far off.)

 multiple algorithms to the CHAOS operator
as discussed on lines https://llllllll.co/t/teletype-chaos/9785/35

so far i have only tested in the TT simulator. i would like to do a more thorough check that numerical behavior is basically as expected.

i took the liberty of arbitrarily scaling the parameter input to [0, 10000], since this will have different meanings for different algos. state/output is still in [-10000, 10000]; some algos may have only unipolar output depending on input.

celullar automata algo is a special case, since the state and parameters are both relatively small integers by nature. they are left unscaled.

## TODO

- maybe add an LCG mode, and whatever else seems interesting.
- cellular automata output scaling is kind of weird: states are stored as bitfields in a uint8; it should really return the sum of bits, not the value itself.
- i am also not sure that the 'neighbor code' interpretation first the de facto standard defined by Wolfram. so e.g. 'rule 110' might not give what you expect.

`chaos_scale_values` should be called on operator init (i'm not sure where that happens) and whenever the algorithm is changed.